### PR TITLE
Fix timeout issue due to responses not being disposed

### DIFF
--- a/ZohoCRM/CRM/Library/Api/Response/APIResponse.cs
+++ b/ZohoCRM/CRM/Library/Api/Response/APIResponse.cs
@@ -16,7 +16,7 @@ namespace ZCRMSDK.CRM.Library.Api.Response
 
         public APIResponse() { }
 
-        public APIResponse(HttpWebResponse response) : base(response) { }
+        public APIResponse(int statusCode, string responseString, WebHeaderCollection headers) : base(statusCode, responseString, headers) { }
 
         public ZCRMEntity Data { get => data; set => data = value; }
         public string Message { get => message; private set => message = value; }

--- a/ZohoCRM/CRM/Library/Api/Response/BulkAPIResponse.cs
+++ b/ZohoCRM/CRM/Library/Api/Response/BulkAPIResponse.cs
@@ -18,7 +18,7 @@ namespace ZCRMSDK.CRM.Library.Api.Response
 
         public BulkAPIResponse() { }
 
-        public BulkAPIResponse(HttpWebResponse response) : base(response)
+        public BulkAPIResponse(int statusCode, string responseString, WebHeaderCollection headers) : base(statusCode, responseString, headers) 
         {
             SetInfo();
         }


### PR DESCRIPTION
Ran into timeout issues after two requests/responses due to the responses not being correctly disposed/closed.

The Zoho server allows X concurrent connections (two in this case) before not allowing anymore. Closing the response is necessary to end the connection(s).

See documentation here:
https://docs.microsoft.com/en-us/dotnet/api/system.net.httpwebresponse.close?view=netframework-4.7.2#System_Net_HttpWebResponse_Close