### PR TITLE
Corrected mistake in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Package Manager:
 
 	>dotnet add package ZCRMSDK --version 2.1.0/
 
->**Note:** The C# SDK is built against for .net standard 2.0.
+>**Note:** The C# SDK is built against .net framework v4.6.1.
 
 Configurations
 --------------


### PR DESCRIPTION
The project is not built against/for .NET Standard. It is built against .NET Framework v4.6.1 and the NuGet package tells you as much when you try to install it into a .NET Standard 2.0 project.
Project file where the target is located:
https://github.com/zoho/zcrm-csharp-sdk/blob/master/ZohoCRM/ZCRMSDK.csproj#L15